### PR TITLE
Added support for Datatables 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "laravel/framework": "^5.1",
         "laravelcollective/html": "^5.1",
         "illuminate/support": "^5.1",
-        "yajra/laravel-datatables-oracle": "~5.0",
+        "yajra/laravel-datatables-oracle": "~6.0",
         "jenssegers/date": "^3.0"
     },
     "license": "MIT",

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -12,8 +12,8 @@ use Kordy\Ticketit\Models\Category;
 use Kordy\Ticketit\Models\Attachment;
 use Kordy\Ticketit\Requests\PrepareTicketStoreRequest;
 use Kordy\Ticketit\Requests\PrepareTicketUpdateRequest;
-use yajra\Datatables\Datatables;
-use yajra\Datatables\Engines\EloquentEngine;
+use Yajra\Datatables\Datatables;
+use Yajra\Datatables\Engines\EloquentEngine;
 
 class TicketsController extends Controller
 {


### PR DESCRIPTION
I have added support for using the new datatables plugin version as per https://github.com/yajra/laravel-datatables#upgrading-from-v5x-to-v6x.

All features seem to be working as they where before.
