### PR TITLE
Update TicketsController.php

### DIFF
--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -73,7 +73,7 @@ class TicketsController extends Controller
     {
 
         $collection->editColumn('subject', function ($ticket) {
-            return link_to_route(
+            return (string) link_to_route(
                 Setting::grab('main_route') . '.show',
                 $ticket->subject,
                 $ticket->id


### PR DESCRIPTION
laravel collective 5.2 helper functions return \Illuminate\Support\HtmlString object instead of string and it's not always casted to string by default (in views, it's ok, but when using them elsewhere you should care of this)
