### PR TITLE
Revert "Fixes initial migration error during clean installation"

### DIFF
--- a/src/Controllers/InstallController.php
+++ b/src/Controllers/InstallController.php
@@ -214,7 +214,6 @@ class InstallController extends Controller
             $migration_arr [] = $migration_parent->migration;
         }
 
-        $migration_arr = array();
         foreach ($tables as $table) {
             if (!in_array($table, $migration_arr)) {
                 $inactiveMigrations [] = $table;

--- a/src/Controllers/InstallController.php
+++ b/src/Controllers/InstallController.php
@@ -203,6 +203,7 @@ class InstallController extends Controller
     public function inactiveMigrations()
     {
         $inactiveMigrations = [];
+        $migration_arr = [];
 
         // Package Migrations
         $tables = $this->migrations_tables;


### PR DESCRIPTION
TicketitServiceProvider would not boot properly as all migrations were showing as having not run. This commit reverts the code which was wiping the $migration_arr array.

This reverts commit f21a7fd0fbb4e8e8c0d8c7b776364720bc498b80.
