### PR TITLE
Fix errors with transactional email providers

### DIFF
--- a/src/Controllers/NotificationsController.php
+++ b/src/Controllers/NotificationsController.php
@@ -93,7 +93,7 @@ class NotificationsController extends Controller
                 $m->to($ticket->agent->email, $ticket->agent->name);
             }
 
-            $m->from($notification_owner->email, $notification_owner->name);
+            $m->replyTo($notification_owner->email, $notification_owner->name);
 
             $m->subject($subject);
         };


### PR DESCRIPTION
Many transactional email providers as well as normal email providers only allow you send emails from domain which you control. If you do not, an error is thrown such as: 
![Sparkpost Error](http://puu.sh/ps6x7/9ab847078f.png)

This changes the ticketit to use the address as the replyTo, instead of the from address (the from address is taken from the laravel mail config file)
