### PR TITLE
Fixed route parameter name in Middleware

### DIFF
--- a/src/Middleware/ResAccessMiddleware.php
+++ b/src/Middleware/ResAccessMiddleware.php
@@ -31,7 +31,7 @@ class ResAccessMiddleware
 
         // if this is a ticket show page
         if ($request->route()->getName() == Setting::grab('main_route').'.show') {
-            $ticket_id = $request->route(Setting::grab('main_route'));
+            $ticket_id = $request->route('ticket');
         }
 
         // if this is a new comment on a ticket


### PR DESCRIPTION
In the routes.php file the resource routes for tickets have the parameter always mapped to "ticket", so this commit fixes a bug where the middleware would break when the main route was changed to something other than "ticket"
