### PR TITLE
Removed unnecessary element with class "row"

### DIFF
--- a/src/Views/index.blade.php
+++ b/src/Views/index.blade.php
@@ -5,10 +5,8 @@
 @stop
 
 @section('content')
-    <div class="row">
-        @include('ticketit::shared.header')
-        @include('ticketit::tickets.index')
-    </div>
+    @include('ticketit::shared.header')
+    @include('ticketit::tickets.index')
 @stop
 
 @section('footer')


### PR DESCRIPTION
Problem: Since there are no columns, content extends beyond container because of the `<div class="row"></div>` that has negative margins.
