### PR TITLE
Fix for failing select on migrations table when a prefix exist on the…

### DIFF
--- a/src/Controllers/InstallController.php
+++ b/src/Controllers/InstallController.php
@@ -209,7 +209,7 @@ class InstallController extends Controller
         $tables = $this->migrations_tables;
 
         // Application active migrations
-        $migrations = DB::select('select * from migrations');
+        $migrations = DB::select('select * from ' . DB::getTablePrefix() . 'migrations');
 
         foreach ($migrations as $migration_parent) { // Count active package migrations
             $migration_arr [] = $migration_parent->migration;


### PR DESCRIPTION
Hello, created this small fix, I am working with you great code on a larger project, this line kept failing for me because I was using db prefixes.  
