### PR TITLE
Paginate Items

### DIFF
--- a/src/Views/index.blade.php
+++ b/src/Views/index.blade.php
@@ -18,6 +18,7 @@
 	        processing: false,
 	        serverSide: true,
 	        responsive: true,
+            pageLength: {{ $setting->grab('paginate_items') }},
         	lengthMenu: {{ json_encode($setting->grab('length_menu')) }},
 	        ajax: '{!! route($setting->grab('main_route').'.data', $complete) !!}',
 	        language: {


### PR DESCRIPTION
Use the existing setting 'paginate_items' to set the default page length in the datatables.

Signed-off-by: Josep Rius Font <josepriusfont@gmail.com>