### PR TITLE
Added autoassign parameter for agent category assignment

### DIFF
--- a/src/Controllers/AgentsController.php
+++ b/src/Controllers/AgentsController.php
@@ -6,15 +6,17 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 use Kordy\Ticketit\Models\Agent;
+use Kordy\Ticketit\Models\Category;
 use Kordy\Ticketit\Models\Setting;
 
 class AgentsController extends Controller
 {
     public function index()
     {
-        $agents = Agent::agents()->get();
+        $agents = Agent::agents()->with('categories')->get();
+		$categories=Category::get();
 
-        return view('ticketit::admin.agent.index', compact('agents'));
+        return view('ticketit::admin.agent.index', compact('agents','categories'));
     }
 
     public function create()
@@ -104,8 +106,20 @@ class AgentsController extends Controller
      */
     public function syncAgentCategories($id, Request $request)
     {
-        $form_cats = ($request->input('agent_cats') == null) ? [] : $request->input('agent_cats');
+        $form_cats = $fc = ($request->input('agent_cats') == null) ? [] : $request->input('agent_cats');
+		$form_auto=($request->input('agent_cats_autoassign') == null) ? [] : $request->input('agent_cats_autoassign');
+		
+		// Attach Autoassign parameter
+		if ($form_cats){
+			$form_cats=[];
+			foreach ($fc as $cat){
+				$form_cats[$cat]=['autoassign'=>(in_array($cat,$form_auto)?"1":"0")];				
+			}		
+		}
+		
         $agent = Agent::find($id);
-        $agent->categories()->sync($form_cats);
+		
+		// Update Agent Categories in ticketit_categories_users
+		$agent->categories()->sync($form_cats);
     }
 }

--- a/src/Migrations/2017_02_27_141336_update_ticketit_categories_users_table.php
+++ b/src/Migrations/2017_02_27_141336_update_ticketit_categories_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateTicketitCategoriesUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ticketit_categories_users', function (Blueprint $table) {
+            $table->boolean('autoassign')->comment('new tickets autoassign enabled')->default('1');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ticketit_categories_users', function (Blueprint $table) {
+            $table->dropColumn('autoassign');
+        });
+    }
+}

--- a/src/Models/Agent.php
+++ b/src/Models/Agent.php
@@ -161,7 +161,7 @@ class Agent extends User
      */
     public function categories()
     {
-        return $this->belongsToMany('Kordy\Ticketit\Models\Category', 'ticketit_categories_users', 'user_id', 'category_id');
+        return $this->belongsToMany('Kordy\Ticketit\Models\Category', 'ticketit_categories_users', 'user_id', 'category_id')->withPivot('autoassign');
     }
 
     /**

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -34,6 +34,6 @@ class Category extends Model
      */
     public function agents()
     {
-        return $this->belongsToMany('\Kordy\Ticketit\Models\Agent', 'ticketit_categories_users', 'category_id', 'user_id');
+        return $this->belongsToMany('\Kordy\Ticketit\Models\Agent', 'ticketit_categories_users', 'category_id', 'user_id')->withPivot('autoassign');
     }
 }

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -196,7 +196,7 @@ class Ticket extends Model
     public function autoSelectAgent()
     {
         $cat_id = $this->category_id;
-        $agents = Category::find($cat_id)->agents()->with(['agentTotalTickets' => function ($query) {
+        $agents = Category::find($cat_id)->agents()->wherePivot('autoassign','1')->with(['agentTotalTickets' => function ($query) {
             $query->addSelect(['id', 'agent_id']);
         }])->get();
         $count = 0;

--- a/src/Public/js/agent_index.js
+++ b/src/Public/js/agent_index.js
@@ -1,0 +1,12 @@
+$(function(){
+	$('.jquery_agent_cat').click(function(){
+		var checked=$(this).hasClass('checked');
+		if (checked){
+			$(this).removeClass('checked');
+			$('#'+$(this).attr('id')+"_auto").prop('checked',false).prop('disabled','disabled');			
+		}else{
+			$(this).addClass('checked');
+			$('#'+$(this).attr('id')+"_auto").prop('checked','checked').prop('disabled',false);
+		}
+	});
+});

--- a/src/Views/admin/agent/index.blade.php
+++ b/src/Views/admin/agent/index.blade.php
@@ -29,7 +29,7 @@
                         <td>{{ trans('ticketit::admin.table-id') }}</td>
                         <td>{{ trans('ticketit::admin.table-name') }}</td>
                         <td>{{ trans('ticketit::admin.table-categories') }}</td>
-                        <td>{{ trans('ticketit::admin.table-join-category') }}</td>
+						<td>Autoassign on categories</td>                        
                         <td>{{ trans('ticketit::admin.table-remove-agent') }}</td>
                     </tr>
                 </thead>
@@ -48,24 +48,70 @@
                                     {{  $category->name }}
                                 </span>
                             @endforeach
-                        </td>
-                        <td>
-                            {!! CollectiveForm::open([
+							
+							<button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#CategoriesPopupAgent{{ $agent->id }}">
+							  Edit
+							</button>
+							
+							<div class="modal fade" id="CategoriesPopupAgent{{ $agent->id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+							  <div class="modal-dialog" role="document">
+								<div class="modal-content">
+								  <div class="modal-header">
+									<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+									<h4 class="modal-title" id="myModalLabel">Agent categories</h4>
+								  </div>
+								  <div class="modal-body">
+								  <h3 class="pull-left">Agent: {{ $agent->name }}</h3>
+									{!! CollectiveForm::open([
                                             'method' => 'PATCH',
                                             'route' => [
                                                         $setting->grab('admin_route').'.agent.update',
                                                         $agent->id
                                                         ],
                                             ]) !!}
-                            @foreach(\Kordy\Ticketit\Models\Category::all() as $agent_cat)
-                                <input name="agent_cats[]"
-                                       type="checkbox"
-                                       value="{{ $agent_cat->id }}"
-                                       {!! ($agent_cat->agents()->where("id", $agent->id)->count() > 0) ? "checked" : ""  !!}
-                                       > {{ $agent_cat->name }}
+									<table class="table table-hover table-striped">
+										<thead><th>Category</th>
+										<th>Active</th>
+										<th>Autoassign enabled</th></thead>
+										<tbody>
+										@foreach($categories as $agent_cat)
+											<tr>
+											<td>{{ $agent_cat->name }}</td>
+											<td><input id="checkbox_agent_{!!$agent->id!!}_cat_{!! $agent_cat->id !!}" class="jquery_agent_cat{!! (count($agent->categories->whereIn('id',$agent_cat->id))>0) ? " checked" : ""  !!}" name="agent_cats[]"
+										   type="checkbox"
+										   value="{{ $agent_cat->id }}"
+										   {!! (count($agent->categories->whereIn('id',$agent_cat->id))>0) ? "checked=\"checked\"" : ""  !!}
+										   ></td>
+											<td><input id="checkbox_agent_{!!$agent->id!!}_cat_{!! $agent_cat->id !!}_auto" name="agent_cats_autoassign[]"
+										   type="checkbox"
+										   value="{{ $agent_cat->id }}" {!! ($agent->categories->whereIn('id',$agent_cat->id)->first()['pivot']['autoassign']==0) ? "" : "checked=\"checked\""  !!} 
+										   {!! (count($agent->categories->whereIn('id',$agent_cat->id)) == 0) ? "disabled=\"disabled\"" : ""  !!}
+										   
+										   ></td>
+											</tr>
+										@endforeach
+										</tbody>
+									</table>
+								  </div>
+								  <div class="modal-footer">
+									<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+									{!! CollectiveForm::submit('Update', ['class' => 'btn btn-info']) !!}
+								  </div>
+								  
+									{!! CollectiveForm::close() !!}
+								</div>
+							  </div>
+							</div>
+                        </td>
+						<td>
+                            @foreach($agent->categories as $category)
+								@if ($category->pivot->autoassign==1)
+									<span style="color: {{ $category->color }}">
+										{{  $category->name }}
+									</span>
+								@endif
+								
                             @endforeach
-                            {!! CollectiveForm::submit(trans('ticketit::admin.btn-join'), ['class' => 'btn btn-info btn-sm']) !!}
-                            {!! CollectiveForm::close() !!}
                         </td>
                         <td>
                             {!! CollectiveForm::open([
@@ -83,7 +129,7 @@
                 @endforeach
                 </tbody>
             </table>
-
         @endif
     </div>
+	<script src="{!! asset('vendor/ticketit/js/agent_index.js') !!}"></script>
 @stop


### PR DESCRIPTION
This update adds a new parameter "autoassign" that it's stored in the agent_category pivot table and it's meant to solve our particular scenario, where I have at the moment two categories:
1. The first one, is a category where I have one agent that has to check all new tickets. If it's not for her, she has to be able to assign that ticket to another agent in the category (nothing new in this case)
2. The second one is the IT main category:
- We want to configure a fake agent with a department shared mail account, that gets all new tickets. We all have that email configured so everyone is going to know about new tickets.
- Later, we want to distribute these tickets manually to whom is the best agent on each case, at least for the first support step

I've tried to improve eloquent queries a bit. Also I have'nt applied new template fields to translation files, so If you think it's worth to add this code I'll finish that part up as soon as I can.

Comments and suggestions are all welcome!

