### PR TITLE
Bug correction: Don't allow empty html or whitespaces in content

### DIFF
--- a/src/Controllers/CommentsController.php
+++ b/src/Controllers/CommentsController.php
@@ -5,10 +5,13 @@ namespace Kordy\Ticketit\Controllers;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Kordy\Ticketit\Models;
+use Kordy\Ticketit\Traits\Purifiable;
 
 class CommentsController extends Controller
 {
-    public function __construct()
+    use Purifiable;
+	
+	public function __construct()
     {
         $this->middleware('Kordy\Ticketit\Middleware\IsAdminMiddleware', ['only' => ['edit', 'update', 'destroy']]);
         $this->middleware('Kordy\Ticketit\Middleware\ResAccessMiddleware', ['only' => 'store']);
@@ -43,14 +46,18 @@ class CommentsController extends Controller
      */
     public function store(Request $request)
     {
-        $this->validate($request, [
+        $a_content=$this->purifyHtml($request->get('content'));
+		$request->merge(['content'=>$a_content['content']]);
+		
+		$this->validate($request, [
             'ticket_id'   => 'required|exists:ticketit,id',
             'content'     => 'required|min:6',
         ]);
 
         $comment = new Models\Comment();
 
-        $comment->setPurifiedContent($request->get('content'));
+        $comment->content=$a_content['content'];
+		$comment->html=$a_content['html'];
 
         $comment->ticket_id = $request->get('ticket_id');
         $comment->user_id = \Auth::user()->id;

--- a/src/Controllers/CommentsController.php
+++ b/src/Controllers/CommentsController.php
@@ -10,8 +10,8 @@ use Kordy\Ticketit\Traits\Purifiable;
 class CommentsController extends Controller
 {
     use Purifiable;
-	
-	public function __construct()
+
+    public function __construct()
     {
         $this->middleware('Kordy\Ticketit\Middleware\IsAdminMiddleware', ['only' => ['edit', 'update', 'destroy']]);
         $this->middleware('Kordy\Ticketit\Middleware\ResAccessMiddleware', ['only' => 'store']);
@@ -46,18 +46,18 @@ class CommentsController extends Controller
      */
     public function store(Request $request)
     {
-        $a_content=$this->purifyHtml($request->get('content'));
-		$request->merge(['content'=>$a_content['content']]);
-		
-		$this->validate($request, [
+        $a_content = $this->purifyHtml($request->get('content'));
+        $request->merge(['content'=>$a_content['content']]);
+
+        $this->validate($request, [
             'ticket_id'   => 'required|exists:ticketit,id',
             'content'     => 'required|min:6',
         ]);
 
         $comment = new Models\Comment();
 
-        $comment->content=$a_content['content'];
-		$comment->html=$a_content['html'];
+        $comment->content = $a_content['content'];
+        $comment->html = $a_content['html'];
 
         $comment->ticket_id = $request->get('ticket_id');
         $comment->user_id = \Auth::user()->id;

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -12,10 +12,13 @@ use Kordy\Ticketit\Models\Setting;
 use Kordy\Ticketit\Models\Ticket;
 use Yajra\Datatables\Datatables;
 use Yajra\Datatables\Engines\EloquentEngine;
+use Kordy\Ticketit\Traits\Purifiable;
 
 class TicketsController extends Controller
 {
-    protected $tickets;
+    use Purifiable;
+	
+	protected $tickets;
     protected $agent;
 
     public function __construct(Ticket $tickets, Agent $agent)
@@ -172,7 +175,10 @@ class TicketsController extends Controller
      */
     public function store(Request $request)
     {
-        $this->validate($request, [
+        $a_content=$this->purifyHtml($request->get('content'));		
+		$request->merge(['content'=>$a_content['content']]);
+		
+		$this->validate($request, [
             'subject'     => 'required|min:3',
             'content'     => 'required|min:6',
             'priority_id' => 'required|exists:ticketit_priorities,id',
@@ -182,8 +188,9 @@ class TicketsController extends Controller
         $ticket = new Ticket();
 
         $ticket->subject = $request->subject;
-
-        $ticket->setPurifiedContent($request->get('content'));
+        
+		$ticket->content=$a_content['content'];
+		$ticket->html=$a_content['html'];
 
         $ticket->priority_id = $request->priority_id;
         $ticket->category_id = $request->category_id;
@@ -196,7 +203,7 @@ class TicketsController extends Controller
 
         session()->flash('status', trans('ticketit::lang.the-ticket-has-been-created'));
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
+        #return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
     }
 
     /**
@@ -247,7 +254,10 @@ class TicketsController extends Controller
      */
     public function update(Request $request, $id)
     {
-        $this->validate($request, [
+        $a_content=$this->purifyHtml($request->get('content'));
+		$request->merge(['content'=>$a_content['content']]);
+		
+		$this->validate($request, [
             'subject'     => 'required|min:3',
             'content'     => 'required|min:6',
             'priority_id' => 'required|exists:ticketit_priorities,id',
@@ -260,7 +270,8 @@ class TicketsController extends Controller
 
         $ticket->subject = $request->subject;
 
-        $ticket->setPurifiedContent($request->get('content'));
+        $ticket->content=$a_content['content'];
+		$ticket->html=$a_content['html'];
 
         $ticket->status_id = $request->status_id;
         $ticket->category_id = $request->category_id;

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -10,15 +10,15 @@ use Kordy\Ticketit\Models\Agent;
 use Kordy\Ticketit\Models\Category;
 use Kordy\Ticketit\Models\Setting;
 use Kordy\Ticketit\Models\Ticket;
+use Kordy\Ticketit\Traits\Purifiable;
 use Yajra\Datatables\Datatables;
 use Yajra\Datatables\Engines\EloquentEngine;
-use Kordy\Ticketit\Traits\Purifiable;
 
 class TicketsController extends Controller
 {
     use Purifiable;
-	
-	protected $tickets;
+
+    protected $tickets;
     protected $agent;
 
     public function __construct(Ticket $tickets, Agent $agent)
@@ -175,13 +175,13 @@ class TicketsController extends Controller
      */
     public function store(Request $request)
     {
-        $a_content=$this->purifyHtml($request->get('content'));		
-		$request->merge([
-			'subject'=>trim($request->get('subject')),
-			'content'=>$a_content['content']
-		]);
-		
-		$this->validate($request, [
+        $a_content = $this->purifyHtml($request->get('content'));
+        $request->merge([
+            'subject'=> trim($request->get('subject')),
+            'content'=> $a_content['content'],
+        ]);
+
+        $this->validate($request, [
             'subject'     => 'required|min:3',
             'content'     => 'required|min:6',
             'priority_id' => 'required|exists:ticketit_priorities,id',
@@ -191,9 +191,9 @@ class TicketsController extends Controller
         $ticket = new Ticket();
 
         $ticket->subject = $request->subject;
-        
-		$ticket->content=$a_content['content'];
-		$ticket->html=$a_content['html'];
+
+        $ticket->content = $a_content['content'];
+        $ticket->html = $a_content['html'];
 
         $ticket->priority_id = $request->priority_id;
         $ticket->category_id = $request->category_id;
@@ -206,7 +206,7 @@ class TicketsController extends Controller
 
         session()->flash('status', trans('ticketit::lang.the-ticket-has-been-created'));
 
-        #return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
+        //return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
     }
 
     /**
@@ -257,13 +257,13 @@ class TicketsController extends Controller
      */
     public function update(Request $request, $id)
     {
-        $a_content=$this->purifyHtml($request->get('content'));
-		$request->merge([
-			'subject'=>trim($request->get('subject')),
-			'content'=>$a_content['content']
-		]);
-		
-		$this->validate($request, [
+        $a_content = $this->purifyHtml($request->get('content'));
+        $request->merge([
+            'subject'=> trim($request->get('subject')),
+            'content'=> $a_content['content'],
+        ]);
+
+        $this->validate($request, [
             'subject'     => 'required|min:3',
             'content'     => 'required|min:6',
             'priority_id' => 'required|exists:ticketit_priorities,id',
@@ -276,8 +276,8 @@ class TicketsController extends Controller
 
         $ticket->subject = $request->subject;
 
-        $ticket->content=$a_content['content'];
-		$ticket->html=$a_content['html'];
+        $ticket->content = $a_content['content'];
+        $ticket->html = $a_content['html'];
 
         $ticket->status_id = $request->status_id;
         $ticket->category_id = $request->category_id;

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -206,7 +206,7 @@ class TicketsController extends Controller
 
         session()->flash('status', trans('ticketit::lang.the-ticket-has-been-created'));
 
-        #return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
+        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
     }
 
     /**

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -176,7 +176,10 @@ class TicketsController extends Controller
     public function store(Request $request)
     {
         $a_content=$this->purifyHtml($request->get('content'));		
-		$request->merge(['content'=>$a_content['content']]);
+		$request->merge([
+			'subject'=>trim($request->get('subject')),
+			'content'=>$a_content['content']
+		]);
 		
 		$this->validate($request, [
             'subject'     => 'required|min:3',
@@ -255,7 +258,10 @@ class TicketsController extends Controller
     public function update(Request $request, $id)
     {
         $a_content=$this->purifyHtml($request->get('content'));
-		$request->merge(['content'=>$a_content['content']]);
+		$request->merge([
+			'subject'=>trim($request->get('subject')),
+			'content'=>$a_content['content']
+		]);
 		
 		$this->validate($request, [
             'subject'     => 'required|min:3',

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -4,12 +4,10 @@ namespace Kordy\Ticketit\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Kordy\Ticketit\Traits\ContentEllipse;
-use Kordy\Ticketit\Traits\Purifiable;
 
 class Comment extends Model
 {
     use ContentEllipse;
-    use Purifiable;
 
     protected $table = 'ticketit_comments';
 

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -5,12 +5,10 @@ namespace Kordy\Ticketit\Models;
 use Illuminate\Database\Eloquent\Model;
 use Jenssegers\Date\Date;
 use Kordy\Ticketit\Traits\ContentEllipse;
-use Kordy\Ticketit\Traits\Purifiable;
 
 class Ticket extends Model
 {
     use ContentEllipse;
-    use Purifiable;
 
     protected $table = 'ticketit';
     protected $dates = ['completed_at'];

--- a/src/Traits/Purifiable.php
+++ b/src/Traits/Purifiable.php
@@ -8,17 +8,17 @@ use Mews\Purifier\Facades\Purifier;
 trait Purifiable
 {
     /**
-     * Updates the content and html attribute of the given model.
+     * Returns an array with both filtered and excluded html
      *
      * @param string $rawHtml
      *
-     * @return \Illuminate\Database\Eloquent\Model $this
+     * @return array
      */
-    public function setPurifiedContent($rawHtml)
+    public function purifyHtml($rawHtml)
     {
-        $this->content = Purifier::clean($rawHtml, ['HTML.Allowed' => '']);
-        $this->html = Purifier::clean($rawHtml, Setting::grab('purifier_config'));
+        $a_html['content']= Purifier::clean($rawHtml, ['HTML.Allowed' => '']);
+        $a_html['html']= Purifier::clean($rawHtml, Setting::grab('purifier_config'));
 
-        return $this;
+        return $a_html;
     }
 }

--- a/src/Traits/Purifiable.php
+++ b/src/Traits/Purifiable.php
@@ -8,16 +8,16 @@ use Mews\Purifier\Facades\Purifier;
 trait Purifiable
 {
     /**
-     * Returns an array with both filtered and excluded html
+     * Returns an array with both filtered and excluded html.
      *
      * @param string $rawHtml
      *
      * @return array
      */
     public function purifyHtml($rawHtml)
-    {        
-		$a_html['content']= trim(Purifier::clean($rawHtml, ['HTML.Allowed' => '']),chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
-        $a_html['html']= trim(Purifier::clean($rawHtml, Setting::grab('purifier_config')),chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
+    {
+        $a_html['content'] = trim(Purifier::clean($rawHtml, ['HTML.Allowed' => '']), chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
+        $a_html['html'] = trim(Purifier::clean($rawHtml, Setting::grab('purifier_config')), chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
 
         return $a_html;
     }

--- a/src/Traits/Purifiable.php
+++ b/src/Traits/Purifiable.php
@@ -15,9 +15,9 @@ trait Purifiable
      * @return array
      */
     public function purifyHtml($rawHtml)
-    {
-        $a_html['content']= Purifier::clean($rawHtml, ['HTML.Allowed' => '']);
-        $a_html['html']= Purifier::clean($rawHtml, Setting::grab('purifier_config'));
+    {        
+		$a_html['content']= trim(Purifier::clean($rawHtml, ['HTML.Allowed' => '']),chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
+        $a_html['html']= trim(Purifier::clean($rawHtml, Setting::grab('purifier_config')),chr(0xC2).chr(0xA0)." \t\n\r\0\x0B");
 
         return $a_html;
     }


### PR DESCRIPTION
There are currently some errors regarding empty content in several fields:

**Subject**
- Whitespaces in the beginning or the end of are treated as valid characters.

**Ticket description, Ticket comment**
- Whitespaces in the beginning or the end are treated as valid characters.
- Not visible HTML (for example empty rows) are treated as valid characters.
- Validation required lenght is based on html input

Corrections applied:
- Input trimming (both for subject and content)
- Content validation now uses the purified content without html tags. This prevents also accepting content that includes a screenshot without any text before or after it.