### PR TITLE
Added a cache of 10 secs for the agent call to share in the views.

### DIFF
--- a/src/TicketitServiceProvider.php
+++ b/src/TicketitServiceProvider.php
@@ -37,7 +37,9 @@ class TicketitServiceProvider extends ServiceProvider
             // Send the Agent User model to the view under $u
             view()->composer('*', function ($view) {
                 if (auth()->check()) {
-                    $u = Agent::find(auth()->user()->id);
+                    $u = \Cache::remember('user_agent', \Carbon\Carbon::now()->addSeconds(10), function () {
+                        return Agent::find(auth()->user()->id);;
+                    });
                     $view->with('u', $u);
                 }
                 $setting = new Setting();

--- a/src/TicketitServiceProvider.php
+++ b/src/TicketitServiceProvider.php
@@ -38,7 +38,7 @@ class TicketitServiceProvider extends ServiceProvider
             view()->composer('*', function ($view) {
                 if (auth()->check()) {
                     $u = \Cache::remember('user_agent', \Carbon\Carbon::now()->addSeconds(10), function () {
-                        return Agent::find(auth()->user()->id);;
+                        return Agent::find(auth()->user()->id);
                     });
                     $view->with('u', $u);
                 }


### PR DESCRIPTION
Its a temporary fix till we find a better way to handle this.
But at least we got covered the repeated calls to find the Agent trough database call done by every view load.
My suggestion for this: use a trait where user will extend all the functions you trying to use by calling the they APP user.
