### PR TITLE
Fixes potential incorrect pathing to routes.php

### DIFF
--- a/src/TicketitServiceProvider.php
+++ b/src/TicketitServiceProvider.php
@@ -166,7 +166,12 @@ class TicketitServiceProvider extends ServiceProvider
             $main_route_path = Setting::grab('main_route_path');
             $admin_route = Setting::grab('admin_route');
             $admin_route_path = Setting::grab('admin_route_path');
-            include Setting::grab('routes');
+
+            if (file_exists(Setting::grab('routes'))) {
+                include Setting::grab('routes');
+            } else {
+                include(__DIR__.'/routes.php');
+            }
         } elseif (Request::path() == 'tickets-install'
                 || Request::path() == 'tickets-upgrade'
                 || Request::path() == 'tickets'

--- a/src/TicketitServiceProvider.php
+++ b/src/TicketitServiceProvider.php
@@ -170,7 +170,7 @@ class TicketitServiceProvider extends ServiceProvider
             if (file_exists(Setting::grab('routes'))) {
                 include Setting::grab('routes');
             } else {
-                include(__DIR__.'/routes.php');
+                include __DIR__.'/routes.php';
             }
         } elseif (Request::path() == 'tickets-install'
                 || Request::path() == 'tickets-upgrade'


### PR DESCRIPTION
It's a really bad idea to store include file paths in the DB, paths often change.
Here's a fix so that the default routes file is loaded if the one in settings cannot be found.

Fixes #306 