### PR TITLE
Change a routing from action(TicketsController) to route(main_route)

### DIFF
--- a/src/Controllers/InstallController.php
+++ b/src/Controllers/InstallController.php
@@ -276,6 +276,6 @@ class InstallController extends Controller
         $seeder->run();
         session()->flash('status', 'Demo tickets, users, and agents are seeded!');
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
+        return redirect()->route(Setting::grab('main_route') . '.index');
     }
 }

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -232,7 +232,7 @@ class TicketsController extends Controller
 
         session()->flash('status', trans('ticketit::lang.the-ticket-has-been-created'));
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index');
+        return redirect()->route(Setting::grab('main_route') . '.index');
     }
 
     /**

--- a/src/Middleware/IsAdminMiddleware.php
+++ b/src/Middleware/IsAdminMiddleware.php
@@ -4,6 +4,7 @@ namespace Kordy\Ticketit\Middleware;
 
 use Closure;
 use Kordy\Ticketit\Models\Agent;
+use Kordy\Ticketit\Models\Setting;
 
 class IsAdminMiddleware
 {
@@ -21,7 +22,7 @@ class IsAdminMiddleware
             return $next($request);
         }
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index')
+        return redirect()->route(Setting::grab('main_route') . '.index')
             ->with('warning', trans('ticketit::lang.you-are-not-permitted-to-access'));
     }
 }

--- a/src/Middleware/IsAgentMiddleware.php
+++ b/src/Middleware/IsAgentMiddleware.php
@@ -4,6 +4,7 @@ namespace Kordy\Ticketit\Middleware;
 
 use Closure;
 use Kordy\Ticketit\Models\Agent;
+use Kordy\Ticketit\Models\Setting;
 
 class IsAgentMiddleware
 {
@@ -21,7 +22,7 @@ class IsAgentMiddleware
             return $next($request);
         }
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index')
+        return redirect()->route(Setting::grab('main_route'). '.index')
             ->with('warning', trans('ticketit::lang.you-are-not-permitted-to-access'));
     }
 }

--- a/src/Middleware/ResAccessMiddleware.php
+++ b/src/Middleware/ResAccessMiddleware.php
@@ -54,7 +54,7 @@ class ResAccessMiddleware
             return $next($request);
         }
 
-        return redirect()->action('\Kordy\Ticketit\Controllers\TicketsController@index')
+        return redirect()->route(Setting::grab('main_route') . '.index')
             ->with('warning', trans('ticketit::lang.you-are-not-permitted-to-access'));
     }
 }

--- a/src/Views/bootstrap3/shared/nav.blade.php
+++ b/src/Views/bootstrap3/shared/nav.blade.php
@@ -1,8 +1,8 @@
 <div class="panel panel-default">
     <div class="panel-body">
         <ul class="nav nav-pills">
-            <li role="presentation" class="{!! $tools->fullUrlIs(action('\Kordy\Ticketit\Controllers\TicketsController@index')) ? "active" : "" !!}">
-                <a href="{{ action('\Kordy\Ticketit\Controllers\TicketsController@index') }}">{{ trans('ticketit::lang.nav-active-tickets') }}
+            <li role="presentation" class="{!! $tools->fullUrlIs(route(Kordy\Ticketit\Models\Setting::grab('main_route') . '.index')) ? "active" : "" !!}">
+                <a href="{{ route(Kordy\Ticketit\Models\Setting::grab('main_route') . '.index') }}">{{ trans('ticketit::lang.nav-active-tickets') }}
                     <span class="badge">
                          <?php 
                             if ($u->isAdmin()) {
@@ -16,8 +16,8 @@
                     </span>
                 </a>
             </li>
-            <li role="presentation" class="{!! $tools->fullUrlIs(action('\Kordy\Ticketit\Controllers\TicketsController@indexComplete')) ? "active" : "" !!}">
-                <a href="{{ action('\Kordy\Ticketit\Controllers\TicketsController@indexComplete') }}">{{ trans('ticketit::lang.nav-completed-tickets') }}
+            <li role="presentation" class="{!! $tools->fullUrlIs(route(Kordy\Ticketit\Models\Setting::grab('main_route') . '-complete')) ? "active" : "" !!}">
+                <a href="{{ route(Kordy\Ticketit\Models\Setting::grab('main_route') . '-complete') }}">{{ trans('ticketit::lang.nav-completed-tickets') }}
                     <span class="badge">
                         <?php 
                             if ($u->isAdmin()) {

--- a/src/Views/bootstrap4/shared/nav.blade.php
+++ b/src/Views/bootstrap4/shared/nav.blade.php
@@ -1,8 +1,8 @@
 <nav>
     <ul class="nav nav-pills">
         <li role="presentation" class="nav-item">
-            <a class="nav-link {!! $tools->fullUrlIs(action('\Kordy\Ticketit\Controllers\TicketsController@index')) ? "active" : "" !!}"
-                href="{{ action('\Kordy\Ticketit\Controllers\TicketsController@index') }}">{{ trans('ticketit::lang.nav-active-tickets') }}
+            <a class="nav-link {!! $tools->fullUrlIs(route(Kordy\Ticketit\Models\Setting::grab('main_route') . '.index')) ? "active" : "" !!}"
+                href="{{ route(Kordy\Ticketit\Models\Setting::grab('main_route') . '.index') }}">{{ trans('ticketit::lang.nav-active-tickets') }}
                 <span class="badge badge-pill badge-secondary ">
                      <?php 
                         if ($u->isAdmin()) {
@@ -17,8 +17,8 @@
             </a>
         </li>
         <li role="presentation" class="nav-item">
-            <a class="nav-link {!! $tools->fullUrlIs(action('\Kordy\Ticketit\Controllers\TicketsController@indexComplete')) ? "active" : "" !!}"
-                 href="{{ action('\Kordy\Ticketit\Controllers\TicketsController@indexComplete') }}">{{ trans('ticketit::lang.nav-completed-tickets') }}
+            <a class="nav-link {!! $tools->fullUrlIs(route(Kordy\Ticketit\Models\Setting::grab('main_route') . '-complete')) ? "active" : "" !!}"
+                 href="{{ route(Kordy\Ticketit\Models\Setting::grab('main_route') . '-complete') }}">{{ trans('ticketit::lang.nav-completed-tickets') }}
                 <span class="badge badge-pill badge-secondary">
                     <?php 
                         if ($u->isAdmin()) {


### PR DESCRIPTION
TicketsController can be modified in a child class.
And routes can be rewritten to use the ChildTicketsController with the same route names.

But there are places where the full name of the TicketsController is used in the action() method.

I suggest changing action() calls to route().