### PR TITLE
Laravel 7 & 8 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ticketit
 
-A simple helpdesk tickets system for Laravel 5.1+ (5.1 – 5.8 and 6.\*) which integrates smoothly with Laravel default users and auth system. 
+A simple helpdesk tickets system for Laravel 5.1+ (5.1 – 5.8 and 6.* - 7.*) which integrates smoothly with Laravel default users and auth system. 
 It will integrate into your current Laravel project within minutes, and you can offer your customers and your team a nice and simple support ticket system. 
 
 ## Features:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ticketit
 
-A simple helpdesk tickets system for Laravel 5.1+ (5.1 – 5.8 and 6.* - 7.*) which integrates smoothly with Laravel default users and auth system. 
+A simple helpdesk tickets system for Laravel 5.1+ (5.1 – 5.8 and 6.* - 7.* - 8.*) which integrates smoothly with Laravel default users and auth system. 
 It will integrate into your current Laravel project within minutes, and you can offer your customers and your team a nice and simple support ticket system. 
 
 ## Features:

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "laravel-package",
     "keywords": ["laravel","helpdesk", "ticket", "support"],
     "require": {
-        "laravel/framework": "^5.1|^6.0",
+        "laravel/framework": "^5.1|^6.0|^7.0",
         "laravelcollective/html": "^5.1|^6.0",
         "illuminate/support": "^5.1|^6.0",
         "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4",
-        "jenssegers/date": "^3.0",
+        "jenssegers/date": "^3.0|^4.0",
         "mews/purifier": "^2.0|^3.1",
         "doctrine/dbal": "^2.5|^2.6"
 

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "laravel-package",
     "keywords": ["laravel","helpdesk", "ticket", "support"],
     "require": {
-        "laravel/framework": "^5.1|^6.0|^7.0",
+        "laravel/framework": "^5.1|^6.0|^7.0|^8.0",
         "laravelcollective/html": "^5.1|^6.0",
-        "illuminate/support": "^5.1|^6.0|^7.0",
-        "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4",
+        "illuminate/support": "^5.1|^6.0|^7.0|^8.0",
+        "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4|^9.11",
         "jenssegers/date": "^3.0|^4.0",
         "mews/purifier": "^2.0|^3.1|^3.2",
         "doctrine/dbal": "^2.5|^2.6|^2.10"

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
     "name": "kordy/ticketit",
-    "description": "A simple helpdesk tickets system for Laravel 5.1 – 5.8 and 6.* which integrates smoothly with Laravel default users and auth system",
+    "description": "A simple helpdesk tickets system for Laravel 5.1 – 5.8 and 6.* - 7.* which integrates smoothly with Laravel default users and auth system",
     "type": "laravel-package",
     "keywords": ["laravel","helpdesk", "ticket", "support"],
     "require": {
-        "laravel/framework": "^7.0",
-        "laravelcollective/html": "^6.0",
-        "illuminate/support": "^5.1|^6.0",
-        "yajra/laravel-datatables-oracle": "^9.4",
-        "jenssegers/date": "^4.0",
-        "mews/purifier": "^3.2",
-        "doctrine/dbal": "^2.10"
+        "laravel/framework": "^5.1|^6.0|^7.0",
+        "laravelcollective/html": "^5.1|^6.0",
+        "illuminate/support": "^5.1|^6.0|^7.0",
+        "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4",
+        "jenssegers/date": "^3.0|^4.0",
+        "mews/purifier": "^2.0|^3.1|^3.2",
+        "doctrine/dbal": "^2.5|^2.6|^2.10"
 
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "illuminate/support": "^5.1|^6.0",
         "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4",
         "jenssegers/date": "^3.0|^4.0",
-        "mews/purifier": "^2.0|^3.1",
-        "doctrine/dbal": "^2.5|^2.6"
+        "mews/purifier": "^2.0|^3.2",
+        "doctrine/dbal": "^2.5|^2.10"
 
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "type": "laravel-package",
     "keywords": ["laravel","helpdesk", "ticket", "support"],
     "require": {
-        "laravel/framework": "^5.1|^6.0|^7.0",
-        "laravelcollective/html": "^5.1|^6.0",
+        "laravel/framework": "^7.0",
+        "laravelcollective/html": "^6.0",
         "illuminate/support": "^5.1|^6.0",
-        "yajra/laravel-datatables-oracle": "^6.0|^8.0|^9.4",
-        "jenssegers/date": "^3.0|^4.0",
-        "mews/purifier": "^2.0|^3.2",
-        "doctrine/dbal": "^2.5|^2.10"
+        "yajra/laravel-datatables-oracle": "^9.4",
+        "jenssegers/date": "^4.0",
+        "mews/purifier": "^3.2",
+        "doctrine/dbal": "^2.10"
 
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kordy/ticketit",
-    "description": "A simple helpdesk tickets system for Laravel 5.1 – 5.8 and 6.* - 7.* which integrates smoothly with Laravel default users and auth system",
+    "description": "A simple helpdesk tickets system for Laravel 5.1 – 5.8 and 6.* - 7.* - 8.* which integrates smoothly with Laravel default users and auth system",
     "type": "laravel-package",
     "keywords": ["laravel","helpdesk", "ticket", "support"],
     "require": {

--- a/src/Controllers/TicketsController.php
+++ b/src/Controllers/TicketsController.php
@@ -82,7 +82,7 @@ class TicketsController extends Controller
 
         $this->renderTicketTable($collection);
 
-        $collection->editColumn('updated_at', '{!! \Carbon\Carbon::createFromFormat("Y-m-d H:i:s", $updated_at)->diffForHumans() !!}');
+        $collection->editColumn('updated_at', '{!! \Carbon\Carbon::parse($updated_at)->diffForHumans() !!}');
 
         // method rawColumns was introduced in laravel-datatables 7, which is only compatible with >L5.4
         // in previous laravel-datatables versions escaping columns wasn't defaut

--- a/src/Views/bootstrap3/admin/index.blade.php
+++ b/src/Views/bootstrap3/admin/index.blade.php
@@ -239,17 +239,14 @@
 @section('footer')
     @if($tickets_count)
     {{--@include('ticketit::shared.footer')--}}
-    <script type="text/javascript"
-            src="https://www.google.com/jsapi?autoload={
-            'modules':[{
-              'name':'visualization',
-              'version':'1',
-              'packages':['corechart']
-            }]
-          }"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 
     <script type="text/javascript">
-        google.setOnLoadCallback(drawChart);
+        // Load the Visualization API and the corechart package.
+        google.charts.load('current', {'packages':['corechart']});
+
+        // Set a callback to run when the Google Visualization API is loaded.
+        google.charts.setOnLoadCallback(drawChart);
 
         // performance line chart
         function drawChart() {

--- a/src/Views/bootstrap4/admin/index.blade.php
+++ b/src/Views/bootstrap4/admin/index.blade.php
@@ -214,17 +214,13 @@
 @section('footer')
     @if($tickets_count)
     {{--@include('ticketit::shared.footer')--}}
-    <script type="text/javascript"
-            src="https://www.google.com/jsapi?autoload={
-            'modules':[{
-              'name':'visualization',
-              'version':'1',
-              'packages':['corechart']
-            }]
-          }"></script>
-
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
-        google.setOnLoadCallback(drawChart);
+        // Load the Visualization API and the corechart package.
+        google.charts.load('current', {'packages':['corechart']});
+
+        // Set a callback to run when the Google Visualization API is loaded.
+        google.charts.setOnLoadCallback(drawChart);
 
         // performance line chart
         function drawChart() {


### PR DESCRIPTION
Added support for Laravel 7 compatibility and stated that Laravel 8 launched yesterday so, tested if it works and works BUT will comment that later.

- Updated dependencies to latest version compatible with Laravel >7.0
- Fixed Google charts not working on dashboard
![image](https://user-images.githubusercontent.com/6952403/92593043-c579bb80-f2a0-11ea-8c3b-15f735f57ca1.png)
- Fixed some Carbon parsing errors occurring since Laravel 7 while exporting data to the datatables

**For Laravel 8:**
- The package does work **BUT** Laravel templating now comes with tailwind css by default so the bootstrap theme will not work (obviously). I can make a try to port the template to tailwind CSS in a future